### PR TITLE
Fix Emoji Usage Command

### DIFF
--- a/src/commands/emojiUsage.js
+++ b/src/commands/emojiUsage.js
@@ -12,4 +12,4 @@ async function execute({ message, timeInEpoch }) {
     }
 }
 
-module.exports = { emojiUsage: { execute } };
+module.exports = { emojiusage: { execute } };

--- a/src/helpers/emojis.js
+++ b/src/helpers/emojis.js
@@ -12,7 +12,7 @@ function tabulateEmojis(emojis, postHistory) {
 	postHistory.forEach(message => {
 		emojis.forEach(emoji => {
 			const count = occurrences(message[1].content, emoji.name, false);
-			if (count > 1){
+			if (count >= 1){
 				emoji.value = (parseInt(emoji.value) + (count > 3 ? 3 : count)).toString();
 			}
 		})


### PR DESCRIPTION
This PR fixes the command by changing the exported module's object property to lowercase so it matches the `commandList` comparison in `index.js`. Additionally, it solves a bug with emojis being used only once in a message not being tabulated.