### PR TITLE
Respond to twitter URLs with appropriate preview

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const { YoutubeExtractor } = require('@discord-player/extractor')
 const TwitterScraper = require('./src/passive/twitter-scrape');
 const TwitterData = require('./src/common/data/twitter');
 const Discord = require('discord.js');
-const DiscordUser = require('./src/common/data/user')
+const DiscordUser = require('./src/common/data/user');
 const DiscordServer = require('./src/common/data/server');
 const client = new Discord.Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, 
 	GatewayIntentBits.GuildEmojisAndStickers, GatewayIntentBits.MessageContent,
@@ -71,12 +71,12 @@ client.on(Events.MessageCreate, async message => {
 		const url = TwitterScraper.getUrlIfAny(message.content);
 		if (url) {
 			const content = await TwitterScraper.scrapeContent(url);
-			const data = new TwitterData(content)
-			await message.channel.send(data.ConstructDiscordMessage())
+			const data = new TwitterData(content);
+			await message.channel.send(data.ConstructDiscordMessage());
 		}
 	} catch (error) {
 		console.log(error);
-		await message.channel.send("Weird twitter link. Check yourself before you wreck yourself. <:zura:540212494434697236>")
+		await message.channel.send("Weird twitter link. Check yourself before you wreck yourself. <:zura:540212494434697236>");
 	}
 
 	// log emoji usage

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const axios = require('axios');
 const { Collection, Events, GatewayIntentBits, EmbedBuilder } = require('discord.js');
 const { Player } = require('discord-player');
 const { YoutubeExtractor } = require('@discord-player/extractor')
+const TwitterScraper = require('./src/passive/twitter-scrape');
 const Discord = require('discord.js');
 const DiscordUser = require('./src/common/data/user')
 const DiscordServer = require('./src/common/data/server');
@@ -64,6 +66,25 @@ client.on(Events.InteractionCreate, async interaction => {
 client.on(Events.MessageCreate, async message => {
 	if (message.author.bot) return;
 	
+	const url = TwitterScraper.getUrlIfAny(message.content);
+	try {
+		if (url) {
+			const content = await TwitterScraper.scrapeContent(url);
+			const attachment = new Discord.AttachmentBuilder().setFile(content.result.ogVideo[0].url)
+			await message.channel.send({files: [attachment], embeds: [new EmbedBuilder()
+			.setColor('#0099ff')
+			.setTitle(content.result.ogTitle)
+			.setDescription(content.result.ogDescription)
+			.addFields([
+				{
+					name: 'Replies',
+					value: 'idk bro look at the tweet'
+				}
+			])]})}	
+	} catch (error) {
+		console.log(error);
+	}
+
 	// log emoji usage
 	const discordData = await getDiscordData(message);
 	await logUsage(message, discordData);

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ client.on(Events.MessageCreate, async message => {
 	if (message.author.bot) return;
 	
 	try {
-		const url = TwitterScraper.getUrlIfAny(message.content); // Uses regex to find twitter or x url in message
+		const url = TwitterScraper.getUrlIfAny(message.content);
 		if (url) {
 			const content = await TwitterScraper.scrapeContent(url);
 			const data = new TwitterData(content)
@@ -76,6 +76,7 @@ client.on(Events.MessageCreate, async message => {
 		}
 	} catch (error) {
 		console.log(error);
+		await message.channel.send("Weird twitter link. Check yourself before you wreck yourself. <:zura:540212494434697236>")
 	}
 
 	// log emoji usage

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const fs = require('node:fs');
 const path = require('node:path');
-const axios = require('axios');
 const { Collection, Events, GatewayIntentBits, EmbedBuilder } = require('discord.js');
 const { Player } = require('discord-player');
 const { YoutubeExtractor } = require('@discord-player/extractor')

--- a/index.js
+++ b/index.js
@@ -70,17 +70,20 @@ client.on(Events.MessageCreate, async message => {
 	try {
 		if (url) {
 			const content = await TwitterScraper.scrapeContent(url);
-			const attachment = new Discord.AttachmentBuilder().setFile(content.result.ogVideo[0].url)
-			await message.channel.send({files: [attachment], embeds: [new EmbedBuilder()
-			.setColor('#0099ff')
-			.setTitle(content.result.ogTitle)
-			.setDescription(content.result.ogDescription)
-			.addFields([
-				{
-					name: 'Replies',
-					value: 'idk bro look at the tweet'
-				}
-			])]})}	
+			const media = content.result.ogVideo ? content.result.ogVideo[0].url : content.result.ogImage ? TwitterScraper.pullImagesFromMosaic(content.result.ogImage[0].url) : null
+			const files = media.length ? media.map(x => { return new Discord.AttachmentBuilder().setFile(x)}) : [new Discord.AttachmentBuilder().setFile(media)]
+			await message.channel.send({files, embeds: [new EmbedBuilder()
+				.setColor('#0099ff')
+				.setTitle(content.result.ogTitle)
+				.setDescription(content.result.ogDescription)
+				.addFields([
+					{
+						name: 'Replies',
+						value: 'idk bro look at the tweet'
+					}
+				])]
+			})
+		}
 	} catch (error) {
 		console.log(error);
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@discordjs/opus": "^0.9.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "aws-sdk": "^2.715.0",
-        "axios": "^1.6.2",
         "discord-player": "^6.5.0",
         "discord.js": "^14.11.0",
         "dotenv": "^16.1.3",
@@ -491,16 +490,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
-    "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -963,25 +952,6 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -996,19 +966,6 @@
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs-minipass": {
@@ -1771,11 +1728,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
         "@discordjs/opus": "^0.9.0",
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "aws-sdk": "^2.715.0",
+        "axios": "^1.6.2",
         "discord-player": "^6.5.0",
         "discord.js": "^14.11.0",
         "dotenv": "^16.1.3",
         "glob": "^7.1.6",
+        "open-graph-scraper": "^6.3.2",
         "opusscript": "^0.0.8",
         "request": "2.88.2",
         "ytdl-core": "^4.11.4"
@@ -275,6 +277,14 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@ffmpeg-installer/ffmpeg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@ffmpeg-installer/ffmpeg/-/ffmpeg-1.1.0.tgz",
@@ -481,6 +491,16 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
+    "node_modules/axios": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -544,17 +564,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -571,6 +580,11 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
+    "node_modules/chardet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.0.0.tgz",
+      "integrity": "sha512-xVgPpulCooDjY6zH4m9YW3jbkaBe3FKIAvF5sj5t7aBNsVl2ljIE+xwJ4iNgiDZHFQvNIpjdKdVOQvvk5ZfxbQ=="
     },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.12",
@@ -949,6 +963,25 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -963,6 +996,19 @@
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-minipass": {
@@ -1617,6 +1663,20 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open-graph-scraper": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/open-graph-scraper/-/open-graph-scraper-6.3.2.tgz",
+      "integrity": "sha512-3HbQwpSZ42hqqpDmZ3ZUOCuS1TuKqRWm6gEIw/HfqWDzwHaEJJR/WGi1prHD2gBaKYPjAHFaSTjKitJHTwMVPA==",
+      "dependencies": {
+        "chardet": "^2.0.0",
+        "cheerio": "^1.0.0-rc.12",
+        "undici": "^5.26.4",
+        "validator": "^13.11.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/opusscript": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
@@ -1711,6 +1771,11 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -1950,14 +2015,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2108,11 +2165,11 @@
       "peer": true
     },
     "node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "dependencies": {
-        "busboy": "^1.6.0"
+        "@fastify/busboy": "^2.0.0"
       },
       "engines": {
         "node": ">=14.0"
@@ -2163,6 +2220,14 @@
       "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/verror": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@discordjs/opus": "^0.9.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "aws-sdk": "^2.715.0",
-    "axios": "^1.6.2",
     "discord-player": "^6.5.0",
     "discord.js": "^14.11.0",
     "dotenv": "^16.1.3",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "@discordjs/opus": "^0.9.0",
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "aws-sdk": "^2.715.0",
+    "axios": "^1.6.2",
     "discord-player": "^6.5.0",
     "discord.js": "^14.11.0",
     "dotenv": "^16.1.3",
     "glob": "^7.1.6",
+    "open-graph-scraper": "^6.3.2",
     "opusscript": "^0.0.8",
     "request": "2.88.2",
     "ytdl-core": "^4.11.4"

--- a/src/common/data/twitter.js
+++ b/src/common/data/twitter.js
@@ -13,13 +13,13 @@ class TwitterData {
      * Return object can be used directly in a channel.send() discord function.
      */
     ConstructDiscordMessage() {
-        const files = this.content.map(x => { return new AttachmentBuilder().setFile(x)})
+        const files = this.content.map(x => { return new AttachmentBuilder().setFile(x)});
         return {files, embeds: [new EmbedBuilder()
             .setColor('#0099ff')
             .setTitle(this.title)
             .setURL(this.url.split('/').slice(0, 4).join('/'))
             .setDescription(this.description)]
-        }
+        };
     }
 }
 
@@ -42,4 +42,4 @@ function pullImagesFromMosaic(url) {
     return ids.map(id => { return `https://pbs.twimg.com/media/${id}.jpg`});
 }
 
-module.exports = TwitterData
+module.exports = TwitterData;

--- a/src/common/data/twitter.js
+++ b/src/common/data/twitter.js
@@ -8,6 +8,10 @@ class TwitterData {
         this.url = scrapedContent.url;
     }
 
+    /**
+     * Constructs a discord embed message with the attached files of videos or images, depending on twitter data scraped.
+     * Return object can be used directly in a channel.send() discord function.
+     */
     ConstructDiscordMessage() {
         const files = this.content.map(x => { return new AttachmentBuilder().setFile(x)})
         return {files, embeds: [new EmbedBuilder()

--- a/src/common/data/twitter.js
+++ b/src/common/data/twitter.js
@@ -1,0 +1,41 @@
+const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
+
+class TwitterData {
+    constructor(scrapedContent) {
+        this.title = scrapedContent.title;
+        this.description = scrapedContent.description;
+        this.content = ConstructContent(scrapedContent.video || scrapedContent.image);
+        this.url = scrapedContent.url;
+    }
+
+    ConstructDiscordMessage() {
+        const files = this.content.map(x => { return new AttachmentBuilder().setFile(x)})
+        return {files, embeds: [new EmbedBuilder()
+            .setColor('#0099ff')
+            .setTitle(this.title)
+            .setURL(this.url.split('/').slice(0, 4).join('/'))
+            .setDescription(this.description)]
+        }
+    }
+}
+
+function ConstructContent(url) {
+    if (url.includes('mosaic')) {
+        return pullImagesFromMosaic(url);
+    } else return [url];
+}
+
+/**
+ * Pulls image IDs from a twitter mosaic URL and converts them to their twimg url, returning an array of urls.
+ * @param {string} url 
+ * @returns {[string]}
+ */
+function pullImagesFromMosaic(url) {
+    // Split URL to extract image ids from mosaic URL.
+    const split = url.split('/');
+    // Get only the image ids.
+    const ids = split.slice(5,split.length);
+    return ids.map(id => { return `https://pbs.twimg.com/media/${id}.jpg`});
+}
+
+module.exports = TwitterData

--- a/src/passive/twitter-scrape.js
+++ b/src/passive/twitter-scrape.js
@@ -1,6 +1,6 @@
 const ogs = require('open-graph-scraper');
 
-const regExp = /((http|https):){0,1}\/\/(www\.){0,1}(twitter|x)\.com\/(?<user>[a-z0-9_-]+)\/(status(es){0,1})\/(?<id>[\d]+)/i
+const regExp = /((http|https):){0,1}\/\/(www\.){0,1}(twitter|x)\.com\/(?<user>[a-z0-9_-]+)\/(status(es){0,1})\/(?<id>[\d]+)/i;
 
 /**
  * @typedef {Object} ScrapedContent
@@ -22,7 +22,7 @@ async function scrapeContent(url) {
     const options = {
         url,
         fetchOptions: { headers: { 'user-agent': userAgent } }
-    }
+    };
     const response = await ogs(options);
     return {
         success: !response.error,

--- a/src/passive/twitter-scrape.js
+++ b/src/passive/twitter-scrape.js
@@ -16,4 +16,12 @@ function getUrlIfAny(url) {
     return content ? content[0].replace(/(x.com|twitter.com)/, 'fxtwitter.com') : null;
 }
 
-module.exports = { scrapeContent, getUrlIfAny };
+function pullImagesFromMosaic(url) {
+    // Split URL to extract image ids from mosaic URL.
+    const split = url.split('/');
+    // Get only the image ids.
+    const ids = split.slice(5,split.length);
+    return ids.map(id => { return `https://pbs.twimg.com/media/${id}.jpg`});
+}
+
+module.exports = { scrapeContent, getUrlIfAny, pullImagesFromMosaic };

--- a/src/passive/twitter-scrape.js
+++ b/src/passive/twitter-scrape.js
@@ -1,0 +1,19 @@
+const ogs = require('open-graph-scraper');
+
+const regExp = /((http|https):){0,1}\/\/(www\.){0,1}(twitter|x)\.com\/(?<user>[a-z0-9_-]+)\/(status(es){0,1})\/(?<id>[\d]+)/i
+
+async function scrapeContent(url) {
+    const userAgent = 'DiscourseBot/1.0';
+    const options = {
+        url,
+        fetchOptions: { headers: { 'user-agent': userAgent } }
+    }
+    return await ogs(options);
+}
+
+function getUrlIfAny(url) {
+    const content = regExp.exec(url);
+    return content ? content[0].replace(/(x.com|twitter.com)/, 'fxtwitter.com') : null;
+}
+
+module.exports = { scrapeContent, getUrlIfAny };

--- a/src/passive/twitter-scrape.js
+++ b/src/passive/twitter-scrape.js
@@ -34,6 +34,11 @@ async function scrapeContent(url) {
     };
 }
 
+/**
+ * Uses regex to detect twitter.com or x.com URL in message. Returns the fxtwitter equivalent URL.
+ * @param {string} url 
+ * @returns {string}
+ */
 function getUrlIfAny(url) {
     const content = regExp.exec(url);
     return content?.[0].replace(/(x.com|twitter.com)/, 'fxtwitter.com');

--- a/src/passive/twitter-scrape.js
+++ b/src/passive/twitter-scrape.js
@@ -2,26 +2,41 @@ const ogs = require('open-graph-scraper');
 
 const regExp = /((http|https):){0,1}\/\/(www\.){0,1}(twitter|x)\.com\/(?<user>[a-z0-9_-]+)\/(status(es){0,1})\/(?<id>[\d]+)/i
 
+/**
+ * @typedef {Object} ScrapedContent
+ * @property {boolean} success - Was the request successful
+ * @property {string} title - Title of the scraped content
+ * @property {string} description - Description tag of the scraped content
+ * @property {string} image - Image URL if available on content
+ * @property {string} video - Video URL if available on content
+ * @property {string} url - URL of the scraped content
+ */
+
+/**
+ * Scrapes content from twitter.com or x.com url using open-graph-scraper.
+ * @param {string} url 
+ * @returns {ScrapedContent}
+ */
 async function scrapeContent(url) {
     const userAgent = 'DiscourseBot/1.0';
     const options = {
         url,
         fetchOptions: { headers: { 'user-agent': userAgent } }
     }
-    return await ogs(options);
+    const response = await ogs(options);
+    return {
+        success: !response.error,
+        title: response.result.ogTitle,
+        description: response.result.ogDescription,
+        image: response.result.ogImage?.[0].url,
+        video: response.result.ogVideo?.[0].url,
+        url: response.result.ogUrl
+    };
 }
 
 function getUrlIfAny(url) {
     const content = regExp.exec(url);
-    return content ? content[0].replace(/(x.com|twitter.com)/, 'fxtwitter.com') : null;
+    return content?.[0].replace(/(x.com|twitter.com)/, 'fxtwitter.com');
 }
 
-function pullImagesFromMosaic(url) {
-    // Split URL to extract image ids from mosaic URL.
-    const split = url.split('/');
-    // Get only the image ids.
-    const ids = split.slice(5,split.length);
-    return ids.map(id => { return `https://pbs.twimg.com/media/${id}.jpg`});
-}
-
-module.exports = { scrapeContent, getUrlIfAny, pullImagesFromMosaic };
+module.exports = { scrapeContent, getUrlIfAny };


### PR DESCRIPTION
This pull request adds functionality to the bot's `Events.MessageCreate` callback. When a message is detected with a `twitter.com` or `x.com` URL, an open graph request is sent to the `fxtwitter.com` equivalent and the relevant metadata is pulled to construct a discord preview response.