### PR TITLE
Make description null if no text is provided

### DIFF
--- a/src/common/data/twitter.js
+++ b/src/common/data/twitter.js
@@ -3,7 +3,7 @@ const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
 class TwitterData {
     constructor(scrapedContent) {
         this.title = scrapedContent.title;
-        this.description = scrapedContent.description;
+        this.description = scrapedContent.description || null;
         this.content = ConstructContent(scrapedContent.video || scrapedContent.image);
         this.url = scrapedContent.url;
     }


### PR DESCRIPTION
There is an edge case where a tweet is posted with no text. In this case, the Embedded Message should not contain any description, otherwise it will error.