### PR TITLE
Create command to toggle twitter previews

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,16 +66,18 @@ client.on(Events.InteractionCreate, async interaction => {
 client.on(Events.MessageCreate, async message => {
 	if (message.author.bot) return;
 	
-	try {
-		const url = TwitterScraper.getUrlIfAny(message.content);
-		if (url) {
-			const content = await TwitterScraper.scrapeContent(url);
-			const data = new TwitterData(content);
-			await message.channel.send(data.ConstructDiscordMessage());
+	if (TwitterScraper.toggled) {
+		try {
+			const url = TwitterScraper.getUrlIfAny(message.content);
+			if (url) {
+				const content = await TwitterScraper.scrapeContent(url);
+				const data = new TwitterData(content);
+				await message.channel.send(data.ConstructDiscordMessage());
+			}
+		} catch (error) {
+			console.log(error);
+			await message.channel.send("Weird twitter link. Check yourself before you wreck yourself. <:zura:540212494434697236>");
 		}
-	} catch (error) {
-		console.log(error);
-		await message.channel.send("Weird twitter link. Check yourself before you wreck yourself. <:zura:540212494434697236>");
 	}
 
 	// log emoji usage

--- a/src/commands/social/toggle-twitter.js
+++ b/src/commands/social/toggle-twitter.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder, ChannelType } = require('discord.js');
+const TwitterScrape = require('../../passive/twitter-scrape')
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('twitter')
+		.setDescription('Commands for handling bot twitter interactions.')
+		.addBooleanOption(option =>
+			option
+				.setName('preview-toggle')
+				.setDescription('Toggle on/off previews from twitter posts.'))
+		,
+	async execute(interaction) {
+        await interaction.deferReply();
+        await toggleTwitterPreviews(interaction);
+	},
+};
+
+function toggleTwitterPreviews(interaction) {
+    TwitterScrape.toggled = interaction.options.getBoolean('preview-toggle', true);
+    return interaction.followUp(`Twitter previews has been ${TwitterScrape.toggled ? 'enabled' : 'disabled'}!`)
+}

--- a/src/passive/twitter-scrape.js
+++ b/src/passive/twitter-scrape.js
@@ -1,6 +1,7 @@
 const ogs = require('open-graph-scraper');
 
 const regExp = /((http|https):){0,1}\/\/(www\.){0,1}(twitter|x)\.com\/(?<user>[a-z0-9_-]+)\/(status(es){0,1})\/(?<id>[\d]+)/i;
+var toggled = false;
 
 /**
  * @typedef {Object} ScrapedContent
@@ -44,4 +45,4 @@ function getUrlIfAny(url) {
     return content?.[0].replace(/(x.com|twitter.com)/, 'fxtwitter.com');
 }
 
-module.exports = { scrapeContent, getUrlIfAny };
+module.exports = { scrapeContent, getUrlIfAny, toggled };


### PR DESCRIPTION
Twitter seems to have fixed their open graph issues, allowing discord to pull twitter previews natively now. In case this no longer is the case in the future, we're adding a feature flag to enable/disable twitter previews from the bot using the command `/twitter preview-toggle`.